### PR TITLE
Update NuGets/Support Lower VS Version

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -17,6 +17,7 @@ on:
         - Debug
 
 env:
+  DOTNET_NOLOGO: true
   # this variable is set in Directory.Build.props and specifies which analyser version should be used.
   # The lower the more Visual Studio versions are supported.
   MsCodeAnalysisVersion: 4.0.0

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -16,6 +16,11 @@ on:
         - Release
         - Debug
 
+env:
+  # this variable is set in Directory.Build.props and specifies which analyser version should be used.
+  # The lower the more Visual Studio versions are supported.
+  MsCodeAnalysisVersion: 4.0.0
+
 jobs:
   build:
     runs-on: windows-latest
@@ -36,6 +41,6 @@ jobs:
             $args += '--version-suffix'
             $args += "beta.${{ github.run_number }}"
           }
-          dotnet pack --configuration ${{ inputs.configuration }} --output '${{ runner.temp }}\NuGets' @args
+          dotnet pack --configuration ${{ inputs.configuration }} --output '${{ runner.temp }}\NuGets'
       - name: Push NuGet
         run: dotnet nuget push '${{ runner.temp }}\NuGets\*.nupkg' --api-key '${{ secrets.NUGET_API_KEY }}' --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,10 @@ jobs:
     runs-on: windows-latest
     env:
       DOTNET_NOLOGO: true
-
+      # this variable is set in Directory.Build.props and specifies which analyser version should be used.
+      # The lower the more Visual Studio versions are supported.
+      MsCodeAnalysisVersion: 4.0.0
+      
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET Core SDK 

--- a/.globalconfig
+++ b/.globalconfig
@@ -6,36 +6,13 @@ is_global =  true
 # While it can be confusing, it's still useful
 dotnet_diagnostic.CA1000.severity = none
 
-# CA1031: Do not catch general exception types. While generally a good idea
-# there are situations where we do want to catch exceptions for e.g. logging purposes.
-dotnet_diagnostic.CA1031.severity = none
-
 # CA1062: Validate arguments of public methods:
-# While a good idea for library code, in application code we just rely on NNRT and the compiler.
+# We trust NNRT annotations to do the job.
 dotnet_diagnostic.CA1062.severity = none
-
-# CA1063: Implement IDisposable correctly.
-# Overkill for most use cases if no unmanaged resources and finalizers are involved
-dotnet_diagnostic.CA1063.severity = none
-
-# CA1303: Do not pass literals as localized parameters. We'll localize the necessary parts anyhow.
-dotnet_diagnostic.CA1303.severity = none
-
-# CA1711: Identifiers should not have incorrect suffix.
-# We use Ex for static classes that extend framework classes, e.g. FileEx.
-dotnet_code_quality.CA1711.allowed_suffixes = Ex
-
-# CA1711: Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.
-# We don't care here since we might use keyword for the cli.
-dotnet_diagnostic.CA1716.severity = none
 
 # CA1724: Type names should not match namespaces
 # While understandable, the problems are really that severe and it makes code rather awkward.
 dotnet_diagnostic.CA1724.severity = none
-
-# CA1816: Call GC.SuppressFinalize correctly
-# Only necessary for handling unmanaged resources directly when using a finalizer. Not something we're doing.
-dotnet_diagnostic.CA1816.severity = none
 
 ## IDE Warnings
 

--- a/.globalconfig
+++ b/.globalconfig
@@ -29,6 +29,10 @@ dotnet_code_quality.CA1711.allowed_suffixes = Ex
 # We don't care here since we might use keyword for the cli.
 dotnet_diagnostic.CA1716.severity = none
 
+# CA1724: Type names should not match namespaces
+# While understandable, the problems are really that severe and it makes code rather awkward.
+dotnet_diagnostic.CA1724.severity = none
+
 # CA1816: Call GC.SuppressFinalize correctly
 # Only necessary for handling unmanaged resources directly when using a finalizer. Not something we're doing.
 dotnet_diagnostic.CA1816.severity = none

--- a/Analyzer/AnalyzerReleases.Unshipped.md
+++ b/Analyzer/AnalyzerReleases.Unshipped.md
@@ -2,5 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|----------------------------------------
-DaS1000 | Reliability | Error | NoDiscardAnalyzer
+DaS1000 | Reliability | Warning | NoDiscardAnalyzer
 DaS1001 | Reliability | Warning | NoDiscardAnalyzer

--- a/Analyzer/AnalyzerReleases.Unshipped.md
+++ b/Analyzer/AnalyzerReleases.Unshipped.md
@@ -2,4 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|----------------------------------------
-DaS1000 | Reliability | Warning | NoDiscardAnalyzer
+DaS1000 | Reliability | Error | NoDiscardAnalyzer
+DaS1001 | Reliability | Warning | NoDiscardAnalyzer

--- a/Analyzer/NoDiscardAnalyzer.cs
+++ b/Analyzer/NoDiscardAnalyzer.cs
@@ -20,18 +20,16 @@ public sealed class NoDiscardAnalyzer : DiagnosticAnalyzer
 
     internal const string AdditionalForbiddenDiscardTypesFileName = "TypesNotToDiscard.txt";
 
-    private const string DiagnosticId = "DaS1000";
-
-    public static readonly DiagnosticDescriptor DoNotDiscardResultRule = new DiagnosticDescriptor(DiagnosticId, "Do not ignore return value",
-        "Do not ignore return value",
+    public static readonly DiagnosticDescriptor DoNotDiscardResultRule = new DiagnosticDescriptor("DaS1000", "Do not ignore returned value",
+        "Do not ignore returned value",
         "Reliability",
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Error,
         true,
-        "Do not discard the return value.");
+        "Do not ignore the returned value. The type has been marked as important and should be handled by application code.");
 
-    public static readonly DiagnosticDescriptor NeitherAttributeNorListDeclaredRule = new DiagnosticDescriptor(DiagnosticId, 
-        $"Neither Attribute nor {AdditionalForbiddenDiscardTypesFileName} file defined",
-        "Neither Attribute nor NoDiscard file defined",
+    public static readonly DiagnosticDescriptor NeitherAttributeNorListDeclaredRule = new DiagnosticDescriptor("DaS1001", 
+        "NoDiscard Analyzer not active",
+        $"Neither a NoDiscardAttribute nor {AdditionalForbiddenDiscardTypesFileName} file is defined",
         "Reliability",
         DiagnosticSeverity.Warning,
         true,
@@ -194,11 +192,13 @@ public sealed class NoDiscardAnalyzer : DiagnosticAnalyzer
 
         private static ExpressionSyntax IsolateMethodName(InvocationExpressionSyntax invocation)
         {
+#pragma warning disable CA1508 // Avoid dead conditional code: False positive - the code was taken from the roslyn analyzers themselves.
             return
                 (invocation.Expression as MemberAccessExpressionSyntax)?.Name ??
                 invocation.Expression as IdentifierNameSyntax ??
                 (invocation.Expression as MemberBindingExpressionSyntax)?.Name ??
                 invocation.Expression;
+#pragma warning restore CA1508 // Avoid dead conditional code
         }
 
     }

--- a/Analyzer/NoDiscardAnalyzer.cs
+++ b/Analyzer/NoDiscardAnalyzer.cs
@@ -33,7 +33,8 @@ public sealed class NoDiscardAnalyzer : DiagnosticAnalyzer
         "Reliability",
         DiagnosticSeverity.Warning,
         true,
-        $"Either include the attribute or include a {AdditionalForbiddenDiscardTypesFileName} file.");
+        $"Either include the attribute or include a {AdditionalForbiddenDiscardTypesFileName} file.",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = 
         ImmutableArray.Create(DoNotDiscardResultRule, NeitherAttributeNorListDeclaredRule);

--- a/Analyzer/NoDiscardAnalyzer.cs
+++ b/Analyzer/NoDiscardAnalyzer.cs
@@ -23,7 +23,7 @@ public sealed class NoDiscardAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor DoNotDiscardResultRule = new DiagnosticDescriptor("DaS1000", "Do not ignore returned value",
         "Do not ignore returned value",
         "Reliability",
-        DiagnosticSeverity.Error,
+        DiagnosticSeverity.Warning,
         true,
         "Do not ignore the returned value. The type has been marked as important and should be handled by application code.");
 
@@ -96,7 +96,6 @@ public sealed class NoDiscardAnalyzer : DiagnosticAnalyzer
             .FilterNull()
             .ToImmutableHashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         return true;
-        
     }
 
     private sealed class PerCompilation

--- a/Analyzer/NoDiscardAnalyzer.csproj
+++ b/Analyzer/NoDiscardAnalyzer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,8 +44,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\LICENSE" Pack="true" PackagePath="" />
-    <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/NoDiscardAnalyzer.sln
+++ b/NoDiscardAnalyzer.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.globalconfig = .globalconfig
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
-		LICENSE = LICENSE
 		README.md = README.md
 		TODO.md = TODO.md
 	EndProjectSection

--- a/NoDiscardAnalyzer.sln
+++ b/NoDiscardAnalyzer.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.globalconfig = .globalconfig
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
+		LICENSE = LICENSE
+		README.md = README.md
 		TODO.md = TODO.md
 	EndProjectSection
 EndProject

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # DaS.NoDiscardAnalyzer
-A roslyn analyzer that provides similar functionality to the [[nodiscard]] attribute in C++17.
+A roslyn analyzer that provides similar functionality to the [[nodiscard]] attribute in C++17. 
+
+Supports annotating types as well as specific methods. If a caller ignores the return value of an annotated method a warning is generated. 
+
+## How To Use
+
+Install the NuGet package https://www.nuget.org/packages/DaS.NoDiscardAnalyzer. After installing you must configure the analyzer so it knows what types or methods should not be discarded by the caller. You have multiple options for how to do this.
+
+### Use DaS.NoDiscardAnalyzer.Attributes
+
+The easiest option is to install the https://www.nuget.org/packages/DaS.NoDiscardAnalyzer.Attributes package, which includes the NoDiscardAttribute. Simply annotate methods or types with it.
+
+```[csharp]
+using DaS.NoDiscardAnalyzer.Attributes;
+public static class Example 
+{
+    [NoDiscard] 
+    public static int Foo() => 0xdead; // Ignoring the int returned by this method will cause a compile warning.
+}
+```
+
+### Define your own custom Attribute
+
+If you do not want to use the Attributes NuGet package you can also define your own attribute. The attribute should look identical to the NoDiscardAttribute, but can have a different name and namespace.
+
+```[csharp]
+[AttributeUsage(AttributeTargets.Method |
+                AttributeTargets.ReturnValue |
+                AttributeTargets.Class | 
+                AttributeTargets.Struct | 
+                AttributeTargets.Enum, AllowMultiple = false, Inherited = true)]
+public sealed class NoDiscardAttribute : Attribute
+{
+    public string? Explanation { get; }
+
+    public NoDiscardAttribute(string? explanation = null)
+    {
+        Explanation = explanation;
+    }
+}
+```
+
+You then tell the analyzer to use your package. You can do so 

--- a/TODO.md
+++ b/TODO.md
@@ -2,5 +2,6 @@
 
 - figure out what to change in package to ensure it can read custom propertygroup
 - document analyzer and options on github
-- Support older VS versions in nuget package
-    => figure out what's possible to support?
+- TypesNotToDiscard.txt should be extended to support both types and methods - use standard syntax for it  instead.
+- use explanation property if it is set.
+- test everything with the nuget package

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # Todos for initial release
 
 - figure out what to change in package to ensure it can read custom propertygroup
-- good diagnostic messages!!
 - document analyzer and options on github
+- Support older VS versions in nuget package
+    => figure out what's possible to support?

--- a/Tests/NoDiscardAnalyzer.Tests.csproj
+++ b/Tests/NoDiscardAnalyzer.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="fluentassertions" Version="6.8.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.0.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/NoDiscardAnalyzer.Tests.csproj
+++ b/Tests/NoDiscardAnalyzer.Tests.csproj
@@ -23,10 +23,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="fluentassertions" Version="6.8.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="fluentassertions" Version="6.10.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Vsix/NoDiscardAnalyzer.Vsix.csproj
+++ b/Vsix/NoDiscardAnalyzer.Vsix.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4065" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Updates all NuGets and reduces the required VS version for the analyzer to to VS2022 (4.0.0 release)